### PR TITLE
Add listeners via on, do not die when err happens

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = function (options, middleware) {
     }
 
     var cache = new events.EventEmitter();
+    cache.setMaxListeners(0);
 
     var updating = false;
     function updateCache() {
@@ -36,7 +37,7 @@ module.exports = function (options, middleware) {
             }
 
             updating = false;
-            if (err && options.breakOnError) { return cache.emit('error', err); }
+            if (err && options.breakOnError) { return cache.emit('updateError', err); }
 
             cache.result = req;
             cache.emit('ready', req);
@@ -49,9 +50,7 @@ module.exports = function (options, middleware) {
         next = next || nop;
 
         if (options.breakOnError) {
-            cache.once('error', function (err) {
-                return next(err);
-            });
+            cache.once('updateError', next);
         }
 
         if (cache.result) {

--- a/test/index.js
+++ b/test/index.js
@@ -63,3 +63,26 @@ it('should pass error with breakOnError', function (done) {
         done();
     });
 });
+
+it('should not raise warning when 10+ listeners are set', function (done) {
+    var cached = memorize(function (req, res, next) {
+        setTimeout(function () {
+            req.boop = true;
+            next();
+
+            done();
+        }, 10);
+    });
+
+    for (var i = 0; i < 20; i++) {
+        cached({});
+    }
+});
+
+it('should not fail when error is emitted without listener', function (done) {
+    var cached = memorize({ updateInterval: 10, hotStart: true, breakOnError: true }, function (req, res, next) {
+        next(new Error('oh my...'));
+    });
+
+    setTimeout(done, 20);
+});


### PR DESCRIPTION
Currently if you set {breakOnError: true, hotStart: true} and middleware fails, your worker dies. This happens because if no 'error' event listeners are set for cache object, worker dies.

Example code:

``` javascript
var events = require('events');

var cache = new events.EventEmitter();

setInterval(function () {
  console.log('int');
}, 1000)

cache.once('error', console.log.bind(console))
cache.once('error', console.log.bind(console))

cache.emit('error', new Error('OLOLO1'));
cache.emit('error', new Error('OLOLO2'));
```

Another error is that error is handled with once, and requests can appear faster than 'error' event is dispatched. So I changed once to on and set listeners count to infinity.

Third thing is when 'error' event is dispatched inside updateError and no error listeners exist, worker dies. So I changed the name of event to 'updateError'.

UPD: Если я тут херней какой-то занимаюсь и надо было написать по-русски, скажи :)
